### PR TITLE
Modify language of example

### DIFF
--- a/pages/documentation/examples/extrusion.mdx
+++ b/pages/documentation/examples/extrusion.mdx
@@ -17,7 +17,7 @@ baremaps workflow execute --file examples/extrusion/workflow.json
 
 In the [tileset.json](https://raw.githubusercontent.com/apache/incubator-baremaps/main/examples/extrusion/tileset.json)
 file, notice the SQL query associated with the building layer. Here, the number of levels stored in OSM is multiplied by
-3, which rawly corresponds to the height of a level in meters.
+3, which roughly corresponds to the height of a level in meters.
 
 ```sql
 SELECT id,


### PR DESCRIPTION
Swapped `roughly` in for `rawly` as this better matches English usage.