### PR TITLE
Fix hydration errors wrapping text in div

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -28,26 +28,26 @@ import styles from './index.module.css'
         </Feature>
         <Feature index={0}>
           <h3>Data Pipeline</h3>
-          <p>
+          <div>
             With Baremaps, you can easily create custom data pipelines to consolidate your spatial datasets in PostGIS. 
             Baremaps supports several popular formats such as OsmPbf, ShapeFile, GeoPackage, and FlatGeoBuf, allowing you to seamlessly integrate with your existing workflows.
-          </p>
+          </div>
         </Feature>
         <Feature index={0}>
           <h3>Vector Tiles</h3>
-          <p>
+          <div>
             Baremaps allows you to easily serve and publish custom vector tiles from PostGIS. 
             Whether you need to create maps for web or mobile applications, Baremaps makes it simple and efficient. 
             Additionally, we are continuously working on developing a high-quality base map.
-          </p>
+          </div>
         </Feature>
         <Feature index={0}>
           <h3>Contributing</h3>
-          <p>
+          <div>
             Whether you're an experienced or just getting started, there are many ways to get involved. 
             We are experimenting with a range of new components, including IP to location, 3D Tiles Next, and geocoding, and would love your help. 
             Let's create something amazing together!
-          </p>
+          </div>
         </Feature>
       </Features>
     </div>


### PR DESCRIPTION
Replace `p` tags with `div` tags as text in mdx is automatically wrapped in `p` tags. This caused react hydration error with a `p` tag inside a `p` tag.

The reason for a `div` tag is to separate the `h3` title with the paragraph.

This also fixes the issue when refreshing at the /documentation url, it not longer redirects to the server working directory.