### PR TITLE
Docs/build with mvn

### DIFF
--- a/pages/documentation/developer-manual/how-to-build-with-maven.mdx
+++ b/pages/documentation/developer-manual/how-to-build-with-maven.mdx
@@ -36,13 +36,16 @@ $ export PATH=$PATH:`pwd`/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin/bin
 Executing the `baremaps` command should now result in an output similar to the following:
 
 ```
-Usage: baremaps [COMMAND]
+Usage: baremaps [-V] [COMMAND]
 A toolkit for producing vector tiles.
+  -V, --version   Print version info.
 Commands:
-  import  Import OpenStreetMap data in the Postgresql database.
-  update  Update OpenStreetMap data in the Postgresql database.
-  export  Export vector tiles from the Postgresql database.
-  serve   Serve vector tiles from the the Postgresql database.
+  workflow  Manage a workflow.
+  database  Database commands.
+  map       Map commands.
+  geocoder  Geocoder commands (experimental).
+  iploc     IP to location commands (experimental).
+  ogcapi    OGC API server (experimental).
 ```
 
 From here, head into [Installing PostGIS](/documentation/getting-started/installing-postgis/) if you plan to work with vector tiles.

--- a/pages/documentation/developer-manual/how-to-build-with-maven.mdx
+++ b/pages/documentation/developer-manual/how-to-build-with-maven.mdx
@@ -33,6 +33,8 @@ $ tar -xvf /path-to-project/baremaps-cli/target/apache-baremaps-0.7.2-SNAPSHOT-i
 $ export PATH=$PATH:`pwd`/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin/bin
 ```
 
+> **Note:** Make sure to replace the version number in the above commands with the version number of the release you are using.
+
 Executing the `baremaps` command should now result in an output similar to the following:
 
 ```

--- a/pages/documentation/developer-manual/how-to-build-with-maven.mdx
+++ b/pages/documentation/developer-manual/how-to-build-with-maven.mdx
@@ -29,7 +29,7 @@ Referencing the location of the `baremaps-cli` binary file, you can run the foll
 and place Baremaps into your `PATH`.
 
 ```bash
-$ tar -xvzf /path-to-project/baremaps-cli/target/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin.tar.gz
+$ tar -xvf /path-to-project/baremaps-cli/target/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin.tar.gz
 $ export PATH=$PATH:`pwd`/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin/bin
 ```
 

--- a/pages/documentation/developer-manual/how-to-build-with-maven.mdx
+++ b/pages/documentation/developer-manual/how-to-build-with-maven.mdx
@@ -11,9 +11,9 @@ To start you can run the command `mvn clean package` from the root folder of the
 compilation you should see something similar to the following output in your terminal. 
 
 ```bash
-[INFO] Building zip: /path-to-project/baremaps/baremaps-cli/target/baremaps.zip
+[INFO] Building tar: /path-to-project/baremaps-cli/target/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin.tar.gz
 [INFO] ------------------------------------------------------------------------
-[INFO] Reactor Summary for baremaps 0.7.1-SNAPSHOT:
+[INFO] Reactor Summary for baremaps 0.7.2-SNAPSHOT:
 [INFO] 
 [INFO] baremaps ........................................... SUCCESS [  4.172 s]
 [INFO] baremaps-core ...................................... SUCCESS [ 59.018 s]
@@ -24,13 +24,13 @@ compilation you should see something similar to the following output in your ter
 [INFO] ------------------------------------------------------------------------
 ```
 
-It is important to note the first line in the output above that notes where the location of the `baremaps.zip` file resides.
-Referencing the location of the `baremaps.zip` file, you can run the following to unzip 
+It is important to note the first line in the output above that notes where the location of the `baremaps-cli` binary file resides.
+Referencing the location of the `baremaps-cli` binary file, you can run the following to untar 
 and place Baremaps into your `PATH`.
 
 ```bash
-$ unzip /path-to-project/baremaps/baremaps-cli/target/baremaps.zip
-$ export PATH=$PATH:`pwd`/baremaps/bin
+$ tar -xvzf /path-to-project/baremaps-cli/target/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin.tar.gz
+$ export PATH=$PATH:`pwd`/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin/bin
 ```
 
 Executing the `baremaps` command should now result in an output similar to the following:


### PR DESCRIPTION
- Bump docs from version 0.7.1 to 0.7.2
- Add updated information about new way to install the cli with tar instead of zip
- Update cli command output