### PR TITLE
Fix/server routing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ module.exports = {
   ...withNextra(),
   images: {
     unoptimized: true
-  }
+  },
+  trailingSlash: true
   //reactStrictMode: true
 };


### PR DESCRIPTION
- Add `.nojekyll` to prevent `_next` folder from being ignored
- Add trailingSlash to next config to have `index.html` files in each sub directory for GitHub pages. (see https://stackoverflow.com/questions/70793966/how-to-keep-nextjs-index-files-inside-their-respective-folders-with-next-export)