### PR TITLE
Fix map overflow with border radius

### DIFF
--- a/components/map/style.module.css
+++ b/components/map/style.module.css
@@ -12,4 +12,7 @@
     border-radius: .75rem;
     width: 100%;
     height: 100%;
+    overflow: hidden;
+    /* this fixes the overflow:hidden for canvas - corresponds to 1 black pixel */
+    -webkit-mask-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC);
 }


### PR DESCRIPTION
Fix on the homepage the map border overflow on webkit browsers. The change is very subtle but it keeps the styling consistency.

Issue was discussed here: https://stackoverflow.com/questions/15007903/html5-canvas-with-rounded-corner

![Screenshot 2023-04-27 at 11 05 54](https://user-images.githubusercontent.com/73912641/234815009-17ce1b7c-8a4e-4ebc-8430-6d1d4d8519af.png)

![Screenshot 2023-04-27 at 11 04 34](https://user-images.githubusercontent.com/73912641/234814777-1d72a687-87b2-437a-a4cd-312821e7cf7e.png)

