### PR TITLE
Feature/map-experiments

### DIFF
--- a/src/pages/_meta.json
+++ b/src/pages/_meta.json
@@ -14,5 +14,10 @@
   "documentation": {
     "title": "Documentation",
     "type": "page"
+  },
+  "experiments": {
+    "title": "Experiments",
+    "type": "page",
+    "display": "hidden"
   }
 }

--- a/src/pages/experiments/_meta.json
+++ b/src/pages/experiments/_meta.json
@@ -1,0 +1,5 @@
+{
+  "raster-dem": "Raster DEM",
+  "raster-hillshade": "Raster Hillshade",
+  "basemap-raster-hillshade": "Basemap Raster Hillshade"
+}

--- a/src/pages/experiments/basemap-raster-hillshade.mdx
+++ b/src/pages/experiments/basemap-raster-hillshade.mdx
@@ -1,0 +1,53 @@
+import Map, { getDefaultControls } from '@/components/map';
+import maplibregl from 'maplibre-gl';
+
+# Basemap Raster Hillshade
+
+The following example injects a terrain source and a hillshade layer into the basemap style.
+
+<div style={{ marginTop: 20, height: 550 }}>
+  <Map
+    zoom={4}
+    mapOptions={{
+      maxZoom: 14
+    }}
+    getMapStyle={async () => {
+      const res = await fetch('https://demo.baremaps.com/style.json');
+      const style = await res.json();
+      // Inject the terrain source and hillshade layer
+      style.sources['terrainSource'] = {
+        type: 'raster-dem',
+        tiles: [
+          'https://s3.amazonaws.com/elevation-tiles-prod/geotiff/{z}/{x}/{y}.tif'
+        ],
+        tileSize: 512,
+        maxzoom: 14,
+        minzoom: 0
+      };
+      style.layers.splice(15, 0, {
+        id: 'hills',
+        type: 'hillshade',
+        source: 'terrainSource',
+        layout: {
+          visibility: 'visible'
+        },
+        // We adjust the hillshade layer to overlay the vector layers
+        paint: {
+          'hillshade-accent-color': 'rgba(0,0,0,0)',
+          'hillshade-highlight-color': 'rgba(255,255,255,0.1)',
+          'hillshade-illumination-anchor': 'viewport',
+          'hillshade-illumination-direction': 45,
+          'hillshade-shadow-color': 'rgba(0,0,0,0.05)'
+        }
+      });
+      return style;
+    }}
+    getControls={() => [
+      ...getDefaultControls(),
+      new maplibregl.TerrainControl({
+        source: 'terrainSource',
+        exaggeration: 0.05
+      })
+    ]}
+  />
+</div>

--- a/src/pages/experiments/raster-dem.mdx
+++ b/src/pages/experiments/raster-dem.mdx
@@ -1,0 +1,52 @@
+import Map, { getDefaultControls } from '@/components/map';
+import maplibregl from 'maplibre-gl';
+
+# Raster DEM
+
+The following raster DEM dataset is from [AWS Terrain Tiles](https://registry.opendata.aws/terrain-tiles/).
+
+<div style={{ marginTop: 20, height: 550 }}>
+  <Map
+    zoom={4}
+    mapOptions={{
+      maxZoom: 14
+    }}
+    mapStyle={{
+      version: 8,
+      sources: {
+        rasterSource: {
+          type: 'raster',
+          tiles: [
+            'https://s3.amazonaws.com/elevation-tiles-prod/geotiff/{z}/{x}/{y}.tif'
+          ],
+          tileSize: 512,
+          maxzoom: 14,
+          minzoom: 0
+        },
+        terrainSource: {
+          type: 'raster-dem',
+          tiles: [
+            'https://s3.amazonaws.com/elevation-tiles-prod/geotiff/{z}/{x}/{y}.tif'
+          ],
+          tileSize: 512,
+          maxzoom: 14,
+          minzoom: 0
+        }
+      },
+      layers: [
+        {
+          id: 'raster-layer',
+          type: 'raster',
+          source: 'rasterSource'
+        }
+      ]
+    }}
+    getControls={() => [
+      ...getDefaultControls(),
+      new maplibregl.TerrainControl({
+        source: 'terrainSource',
+        exaggeration: 0.05
+      })
+    ]}
+  />
+</div>

--- a/src/pages/experiments/raster-hillshade.mdx
+++ b/src/pages/experiments/raster-hillshade.mdx
@@ -1,0 +1,71 @@
+import Map, { getDefaultControls } from '@/components/map';
+import maplibregl from 'maplibre-gl';
+
+# Raster Hillshade
+
+This example shows the use of the `hillshade` layer type in `maplibre-gl` to render a hillshade layer on top of a raster DEM layer.
+
+<div style={{ marginTop: 20, height: 550 }}>
+  <Map
+    zoom={4}
+    mapOptions={{
+      maxZoom: 14
+    }}
+    mapStyle={{
+      version: 8,
+      sources: {
+        rasterSource: {
+          type: 'raster',
+          tiles: [
+            'https://s3.amazonaws.com/elevation-tiles-prod/geotiff/{z}/{x}/{y}.tif'
+          ],
+          tileSize: 512,
+          maxzoom: 14,
+          minzoom: 0
+        },
+        terrainSource: {
+          type: 'raster-dem',
+          tiles: [
+            'https://s3.amazonaws.com/elevation-tiles-prod/geotiff/{z}/{x}/{y}.tif'
+          ],
+          tileSize: 512,
+          maxzoom: 14,
+          minzoom: 0
+        }
+      },
+      layers: [
+        {
+          id: 'hills',
+          type: 'hillshade',
+          source: 'terrainSource',
+          layout: {
+            visibility: 'visible'
+          },
+          paint: {
+            'hillshade-accent-color': '#0ac1ff',
+            'hillshade-highlight-color': '#ffffff',
+            'hillshade-illumination-anchor': 'map',
+            'hillshade-illumination-direction': 45,
+            'hillshade-shadow-color': '#000000'
+          }
+        },
+        {
+          id: 'raster-layer',
+          type: 'raster',
+          source: 'rasterSource',
+          // Reduce opacity of raster layer to increase visibility of hillshade layer
+          paint: {
+            'raster-opacity': 0.6
+          }
+        }
+      ]
+    }}
+    getControls={() => [
+      ...getDefaultControls(),
+      new maplibregl.TerrainControl({
+        source: 'terrainSource',
+        exaggeration: 0.05
+      })
+    ]}
+  />
+</div>


### PR DESCRIPTION
Abstract the map component to allow more custom props to the maplibre.Map

Add new map experiments under the `/experiments` route (hidden on website):
- `/experiments/raster-dem`
- `/experiments/raster-hillshade`
- `/experiments/basemap-raster-hillshade`