### PR TITLE
Fix TLD for GeoNames source

### DIFF
--- a/src/pages/documentation/examples/geocoding.mdx
+++ b/src/pages/documentation/examples/geocoding.mdx
@@ -9,7 +9,7 @@ In this tutorial, we demonstrate how to create a geocoding index and then serve 
 
 ## Dataset
 
-The data we will be using comes from [Geonames](https://geonames.com).
+The data we will be using comes from [Geonames](https://www.geonames.org).
 
 ## Generate the index
 


### PR DESCRIPTION
Updates TLD for GeoNames website from incorrect `.com` to `.org` and adds `www.` to address to preserve HTTPS.