### PR TITLE
Fix inspect popup overflow

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -44,7 +44,8 @@ export const getDefaultControls = (): maplibregl.IControl[] => [
     showInspectMapPopupOnHover: false,
     popup: new maplibregl.Popup({
       closeButton: true,
-      closeOnClick: true
+      closeOnClick: true,
+      maxWidth: 'none'
     })
   }),
   // Add the tile boundaries control to the map.

--- a/src/lib/maplibre/dist/maplibre-gl-inspect/maplibre-gl-inspect.css
+++ b/src/lib/maplibre/dist/maplibre-gl-inspect/maplibre-gl-inspect.css
@@ -3,7 +3,13 @@
   display: table;
 }
 
+.maplibregl-inspect_feature {
+  padding: 0 0.75rem;
+}
+
 .maplibregl-inspect_feature:not(:last-child) {
+  padding-bottom: 0.25rem;
+  margin-bottom: 0.25rem;
   border-bottom: 1px solid #ccc;
 }
 
@@ -22,12 +28,13 @@
 
 .maplibregl-inspect_property-value {
   display: table-cell;
-
+  max-width: 200px;
+  word-break: break-all;
 }
 
 .maplibregl-inspect_property-name {
   display: table-cell;
-  padding-right: 10px;
+  padding-right: 15px;
 }
 
 .maplibregl-ctrl-inspect {

--- a/src/pages/_app.mdx
+++ b/src/pages/_app.mdx
@@ -1,6 +1,7 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import '@/lib/maplibre/dist/maplibre-gl-inspect/maplibre-gl-inspect.css';
 import '@/lib/maplibre/dist/maplibre-gl-tile-boundaries/maplibre-gl-tile-boundaries.css';
+import '@/styles/globals.css';
 
 import '@fortawesome/fontawesome-svg-core/styles.css';
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,12 @@
+.maplibregl-popup .maplibregl-popup-content {
+  max-height: 50vh;
+  overflow-y: scroll;
+  pointer-events: all;
+  border-radius: 0.5rem;
+  padding: 0.75rem 0;
+}
+
+.maplibregl-popup .maplibregl-popup-close-button {
+  top: 10px;
+  right: 15px;
+}


### PR DESCRIPTION
- Add global styles for popup custom styles
- Improve `maplibre-gl-inspect.css` styles
- Make popup scrollable vertically
- Fix popup overflow by setting `maxWidth: 'none'`