### PR TITLE
Fix cli paths

### DIFF
--- a/src/pages/documentation/developer-manual/how-to-build-with-maven.mdx
+++ b/src/pages/documentation/developer-manual/how-to-build-with-maven.mdx
@@ -10,9 +10,9 @@ To start you can run the command `./mvnw clean package -DskipTests` from the roo
 compilation you should see something similar to the following output in your terminal.
 
 ```bash
-[INFO] Building tar: /path-to-project/baremaps-cli/target/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin.tar.gz
+[INFO] Building tar: /path-to-project/baremaps-cli/target/apache-baremaps-<version>-SNAPSHOT-incubating-bin.tar.gz
 [INFO] ------------------------------------------------------------------------
-[INFO] Reactor Summary for baremaps 0.7.2-SNAPSHOT:
+[INFO] Reactor Summary for baremaps <version>-SNAPSHOT:
 [INFO]
 [INFO] baremaps ........................................... SUCCESS [  4.172 s]
 [INFO] baremaps-core ...................................... SUCCESS [ 59.018 s]
@@ -28,8 +28,8 @@ Referencing the location of the `baremaps-cli` binary file, you can run the foll
 and place Baremaps into your `PATH`.
 
 ```bash
-tar -xvf ./baremaps-cli/target/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin.tar.gz
-export PATH=$PATH:`pwd`/apache-baremaps-0.7.2-SNAPSHOT-incubating-bin/bin
+tar -xvf ./baremaps-cli/target/apache-baremaps-<version>-SNAPSHOT-incubating-bin.tar.gz -C target/
+export PATH=$PATH:`pwd`/target/apache-baremaps-<version>-SNAPSHOT-incubating-bin/bin
 ```
 
 > **Note:** Make sure to replace the version number in the above commands with the version number of the release you are using.

--- a/src/pages/documentation/developer-manual/ip-to-location.mdx
+++ b/src/pages/documentation/developer-manual/ip-to-location.mdx
@@ -40,7 +40,7 @@ should be applicable to all the RIRs.
 
 A workflow is a directed acyclic graph of steps executed by Baremaps. To download and import the sample OSM data in Postgres, execute the following [workflow](https://raw.githubusercontent.com/apache/incubator-baremaps/main/examples/ip-to-location/workflow.js).
 
-```
+```bash
 baremaps workflow execute --file examples/ip-to-location/workflow.js
 ```
 

--- a/src/pages/documentation/examples/extrusion.mdx
+++ b/src/pages/documentation/examples/extrusion.mdx
@@ -10,7 +10,7 @@ buildings can be extruded with Maplibre. First, start by downloading the OSM dat
 
 To import London data in the database.
 
-```
+```bash
 cd examples/extrusion
 baremaps workflow execute --file workflow.json
 ```

--- a/src/pages/documentation/examples/geoadmin.mdx
+++ b/src/pages/documentation/examples/geoadmin.mdx
@@ -11,7 +11,7 @@ Download an uncompress the archive that contains the GeoTiff.
 If needed, you can now reproject the geotiff in the desired projection before importing it in the database.
 Start by reprojecting the geotiff (EPSG:2056) from LV95 to WebMercator (EPSG:3857)
 
-```
+```bash
 gdalwarp -rc \
   -s_srs epsg:2056 -t_srs epsg:3857 \
   -dstnodata 0 -of GTiff -co tiled=yes \
@@ -24,7 +24,7 @@ Here, the `-nln` argument name the table that contains the data,
 the `-a` argument name the column that contains the elevation,
 the `-i` argument specifies the interval in meters at which contours are generated.
 
-```
+```bash
 gdal_polygonize.py \
   StrassenLaerm_Tag_LV95-3857.tif \
   -f PostgreSQL \
@@ -35,7 +35,7 @@ gdal_polygonize.py \
 The following index can now be created to improve performances.
 When available, a smoothing function such as `ST_ChaikinSmoothing` can be used to improve rendering.
 
-```postgresql
+```sql
 DROP INDEX IF EXISTS geoadmin_traffic_noise_day_gix;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS geoadmin_traffic_noise_day_gix ON geoadmin_traffic_noise_day USING SPGIST(wkb_geometry);
 ```

--- a/src/pages/documentation/examples/geocoding.mdx
+++ b/src/pages/documentation/examples/geocoding.mdx
@@ -15,15 +15,18 @@ The data we will be using comes from [Geonames](https://www.geonames.org).
 
 The following [workflow](https://raw.githubusercontent.com/apache/incubator-baremaps/main/examples/geocoding/workflow.js) will download the Geonames data, decompress it, and finally build the index.
 
-```
-baremaps workflow execute --file examples/geocoding/workflow.js
+```bash
+# Move to the example directory
+cd examples/geocoding
+# Execute the workflow
+baremaps workflow execute --file workflow.js
 ```
 
 ## Serve the data
 
 The following command will serve the Geonames index over HTTP in a simple web application.
 
-```
+```bash
 baremaps geocoder serve --index geocoder-index --port 9000
 ```
 

--- a/src/pages/documentation/examples/geocoding.mdx
+++ b/src/pages/documentation/examples/geocoding.mdx
@@ -16,9 +16,7 @@ The data we will be using comes from [Geonames](https://www.geonames.org).
 The following [workflow](https://raw.githubusercontent.com/apache/incubator-baremaps/main/examples/geocoding/workflow.js) will download the Geonames data, decompress it, and finally build the index.
 
 ```bash
-# Move to the example directory
 cd examples/geocoding
-# Execute the workflow
 baremaps workflow execute --file workflow.js
 ```
 

--- a/src/pages/documentation/examples/import-contour-into-postgis.mdx
+++ b/src/pages/documentation/examples/import-contour-into-postgis.mdx
@@ -58,7 +58,7 @@ To improve the performance of the contour lines,
 we can add some indexes to the database.
 Here's an example of how to create a `SPGIST` index:
 
-```postgresql
+```sql
 DROP INDEX IF EXISTS aster_dem_gix;
 CREATE INDEX IF NOT EXISTS aster_dem_gix ON aster_dem USING SPGIST(wkb_geometry);
 ```
@@ -85,7 +85,7 @@ a smoothing function like ST_ChaikinSmoothing. This function takes
 a geometry as input and returns a smoothed version of that geometry.
 Here's an example of how you could use it:
 
-```postgresql
+```sql
 UPDATE aster_dem
 SET wkb_geometry = ST_ChaikinSmoothing(wkb_geometry, 0.1)
 ```

--- a/src/pages/documentation/examples/import-naturalearth-into-postgis.mdx
+++ b/src/pages/documentation/examples/import-naturalearth-into-postgis.mdx
@@ -15,7 +15,7 @@ Notice that the following steps assume that the Apache Baremaps CLI and PostGIS 
 
 The following workflow will download the Natural Earth data, decompress it, and finally import it in the database.
 
-```
+```bash
 cd examples/naturalearth
 baremaps workflow execute --file workflow.json
 ```

--- a/src/pages/documentation/examples/import-osm-into-postgis.mdx
+++ b/src/pages/documentation/examples/import-osm-into-postgis.mdx
@@ -24,7 +24,7 @@ In this example we will use a tiny extract of OSM for [Liechtenstein](https://en
 A workflow is a directed acyclic graph of steps executed by Baremaps.
 To download and import the sample OSM data in Postgres, execute the following [workflow](https://raw.githubusercontent.com/apache/incubator-baremaps/main/examples/openstreetmap/workflow.json).
 
-```
+```bash
 cd examples/openstreetmap
 baremaps workflow execute --file workflow.json
 ```

--- a/src/pages/documentation/examples/ip-to-location.mdx
+++ b/src/pages/documentation/examples/ip-to-location.mdx
@@ -15,8 +15,11 @@ The data are formatted following [RPSL](https://www.irr.net/docs/rpsl.html) spec
 
 ## Generate the index
 
-```
-baremaps workflow execute --file examples/ip-to-location/workflow.js
+```bash
+# Move to the example directory
+cd examples/ip-to-location
+# Execute the workflow
+baremaps workflow execute --file workflow.js
 ```
 
 The workflow executed in the above command does the following:
@@ -27,7 +30,7 @@ The workflow executed in the above command does the following:
 
 ## Serve the data
 
-```
+```bash
 baremaps iploc serve --database iploc.db --port 9000
 ```
 

--- a/src/pages/documentation/examples/ip-to-location.mdx
+++ b/src/pages/documentation/examples/ip-to-location.mdx
@@ -16,9 +16,7 @@ The data are formatted following [RPSL](https://www.irr.net/docs/rpsl.html) spec
 ## Generate the index
 
 ```bash
-# Move to the example directory
 cd examples/ip-to-location
-# Execute the workflow
 baremaps workflow execute --file workflow.js
 ```
 

--- a/src/pages/documentation/examples/serve-and-export-vector-tiles.mdx
+++ b/src/pages/documentation/examples/serve-and-export-vector-tiles.mdx
@@ -33,7 +33,7 @@ Each of these files are available in the main repository of Apache Baremaps insi
 First `cd` into one of the example directories that corresponds to the data you inserted inside your PostGIS database.
 Then let's preview and edit the map with the sample configuration files by executing the following command in a terminal.
 
-```
+```bash
 baremaps map dev \
   --tileset 'tileset.json' \
   --style 'style.json'
@@ -79,7 +79,7 @@ Baremaps has been conceived with these lasting trends in mind.
 The following command produces a local directory containing precomputed static tiles.
 These tiles can be served with Apache, Nginx, or Caddy, but also copied in a blob store behind a content delivery network, such as Cloudflare, Stackpath, or Fastly.
 
-```
+```bash
 baremaps map export \
   --tileset 'tileset.json' \
   --repository 'tiles/'


### PR DESCRIPTION
- Fixes the path of the cli to be in `./target` instead of at the root. This makes it so that the file is gitignored.
- The version has also been replaced with a placeholder.

- Fixes the path when running the workflows for the examples, containing it's specific data to itself.
- Code blocks language ajusted for consistency